### PR TITLE
Fix including wrong file

### DIFF
--- a/SyliusShopBundle/views/layout.html.twig
+++ b/SyliusShopBundle/views/layout.html.twig
@@ -13,7 +13,7 @@
     {% endblock %}
 
     {% block stylesheets %}
-        {% include '@SyliusUi/_javascripts.html.twig' with {'path': ''} %}
+        {% include '@SyliusUi/_stylesheets.html.twig' with {'path': ''} %}
 
         {{ sonata_block_render_event('sylius.shop.layout.stylesheets') }}
     {% endblock %}


### PR DESCRIPTION
Including javascripts instead of stylesheets.

Also, it would be great to place these files inside the skeleton to make easy to modify it. When user want to create brand new theme he probably don't want SyliusUiBundle assets.